### PR TITLE
Feature: Implement calculated last streamed date for partners

### DIFF
--- a/src/components/GameDetailView.tsx
+++ b/src/components/GameDetailView.tsx
@@ -107,10 +107,14 @@ const GameDetailView: React.FC<GameDetailProps> = ({ store, setStore }) => {
     .filter(p => !askedIds.includes(p.id))
     .filter(p => !deadline || !p.busyUntil || new Date(p.busyUntil) <= deadline);
 
-  const availablePartners = sortPartners(partnersForConsideration, tags);
+  const availablePartners = sortPartners(partnersForConsideration, store.games, tags); // Pass store.games
 
   const busyPartners = store.partners
     .filter(p => !askedIds.includes(p.id) && deadline && p.busyUntil && new Date(p.busyUntil) > deadline);
+  // We don't explicitly sort busyPartners by last streamed date here, but if we did, we'd pass store.games.
+  // The current sort for busyPartners is implicitly by name if their busyUntil dates are the same or not a factor.
+  // If a different sort order for busyPartners that considers lastStreamed is needed, this is where it would change.
+  // For now, only availablePartners sorting is explicitly mentioned as needing the change in the plan.
 
   const askPartner = (pid: string) => {
     const newAsk: AskRecord = { partnerId: pid, askedOn: new Date(), confirmed: false, response: '' };

--- a/src/components/PartnersListView.tsx
+++ b/src/components/PartnersListView.tsx
@@ -2,9 +2,9 @@
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
-import { Partner, Store, DateFormatOption } from '../types';
+import { Partner, Store } from '../types';
 import { formatDate } from '../helpers/dateFormatter';
-import { sortPartners } from '../helpers/partnerSorters';
+import { sortPartners, calculateLastStreamed } from '../helpers/partnerSorters'; // Added calculateLastStreamed
 
 interface PartnersListProps {
   store: Store;
@@ -16,7 +16,7 @@ const PartnersListView: React.FC<PartnersListProps> = ({ store, setStore }) => {
 
   // Sort partners using the new helper function.
   // No game-specific tags here, so gameTags argument is undefined.
-  const sortedPartners = sortPartners(store.partners);
+  const sortedPartners = sortPartners(store.partners, store.games); // Pass store.games
 
   const addPartner = () => {
     const newPartner: Partner = {
@@ -51,7 +51,12 @@ const PartnersListView: React.FC<PartnersListProps> = ({ store, setStore }) => {
                   (busy until {formatDate(p.busyUntil, store.settings.dateFormat)})
                 </span>
               )}
-              <span>Last streamed: {p.lastStreamedWith ? formatDate(p.lastStreamedWith, store.settings.dateFormat) : 'Never'}</span>
+              <span>Last streamed: {
+                (() => {
+                  const lastStreamedDate = calculateLastStreamed(p, store.games);
+                  return lastStreamedDate ? formatDate(lastStreamedDate, store.settings.dateFormat) : 'Never';
+                })()
+              }</span>
             </div>
           </li>
         ))}


### PR DESCRIPTION
- Added `calculateLastStreamed` helper to determine the effective last streamed date for a partner, considering both `lastStreamedWith` and confirmed game participations.
- Updated `sortPartners` to use this calculated date, ensuring partners are sorted accurately based on their most recent activity.
- Modified `PartnersListView` to display this calculated date and use the updated sorting.
- Modified `GameDetailView` to use the updated sorting for available partners.